### PR TITLE
[update] Round BMI to the second decimal place.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ export const App = () => {
   };
 
   const calcBmi = () => {
-    const newBmi = Math.round(weight / (height * height));
+    const newBmi = Math.round(weight / (height * height)*10)/10;
     setBmi(newBmi);
   };
 


### PR DESCRIPTION
close #8 
 
## Summary
Round BMI to the second decimal place.

## Reason for the change
Because BMI calculation results are displayed as integers.

## What I did
* [x] calcBmi modified.