### PR TITLE
[update]  Explicitly indicate the use of Cockcroft-Gault-equation in the labels of Ccr calculation results.

### DIFF
--- a/src/components/outputArea.jsx
+++ b/src/components/outputArea.jsx
@@ -6,11 +6,11 @@ export const OutputArea = (props) => {
     <div className="output-area">
       <div>
         <p>BMI</p>
-        <p>{bmi}</p>
+        <p>　{bmi}</p>
       </div>
       <div>
-        <p>クレアチニンクリアランス</p>
-        <p>{ccr}mL/min</p>
+        <p>クレアチニンクリアランス推算値(Cockcroft-Gault式)</p>
+        <p>　{ccr}mL/min</p>
       </div>
     </div>
   );


### PR DESCRIPTION
close #10 
 
## Summary
Explicitly indicate the use of Cockcroft-Gault-equation in the labels of Ccr calculation results.

## Reason for the change
* It is difficult to know whether Ccr is an actual value or an estimated value.
* It is difficult to understand what is used in the calculation formula.

## What I did
* [x] Add sentence to Ccr calculation results label.